### PR TITLE
Silence deprecation warning for 1.7+

### DIFF
--- a/django_ace/widgets.py
+++ b/django_ace/widgets.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 from django import forms
-from django.forms.util import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 from django.utils.safestring import mark_safe
 
 


### PR DESCRIPTION
In Django 1.7, `django.forms.util` has been moved to `django.forms.utils` for consistency, and the old import now raises deprecation warnings.

This commit should fix that so I can use `python -W error ...` again :)
