### PR TITLE
showprintmargin option

### DIFF
--- a/django_ace/static/django_ace/widget.js
+++ b/django_ace/static/django_ace/widget.js
@@ -77,6 +77,7 @@
             mode = widget.getAttribute('data-mode'),
             theme = widget.getAttribute('data-theme'),
             wordwrap = widget.getAttribute('data-wordwrap'),
+            showprintmargin = widget.getAttribute('data-showprintmargin'),
             toolbar = prev(widget),
             main_block = toolbar.parentNode;
 
@@ -102,6 +103,9 @@
         }
         if (wordwrap == "true") {
             editor.getSession().setUseWrapMode(true);
+        }
+        if (showprintmargin == "false") {
+            editor.setShowPrintMargin(false);
         }
 
         editor.getSession().on('change', function() {

--- a/django_ace/widgets.py
+++ b/django_ace/widgets.py
@@ -8,12 +8,13 @@ from django.utils.safestring import mark_safe
 
 
 class AceWidget(forms.Textarea):
-    def __init__(self, mode=None, theme=None, wordwrap=False, width="500px", height="300px", *args, **kwargs):
+    def __init__(self, mode=None, theme=None, wordwrap=False, width="500px", height="300px", showprintmargin=True, *args, **kwargs):
         self.mode = mode
         self.theme = theme
         self.wordwrap = wordwrap
         self.width = width
         self.height = height
+        self.showprintmargin = showprintmargin
         super(AceWidget, self).__init__(*args, **kwargs)
 
     @property
@@ -44,6 +45,7 @@ class AceWidget(forms.Textarea):
             ace_attrs["data-theme"] = self.theme
         if self.wordwrap:
             ace_attrs["data-wordwrap"] = "true"
+        ace_attrs["data-showprintmargin"] = "true" if self.showprintmargin else "false"
 
         textarea = super(AceWidget, self).render(name, value, attrs)
 


### PR DESCRIPTION
An option to hide the print margin by passing showprintmargin=False into the widget attributes. Preserves backwards compatibility by using the current default of showing the margin.
