### PR TITLE
Add window.djangoAceRegistry to interact with existing editors

### DIFF
--- a/django_ace/static/django_ace/widget.js
+++ b/django_ace/static/django_ace/widget.js
@@ -83,6 +83,12 @@
             toolbar = prev(widget),
             main_block = toolbar.parentNode;
 
+        // Global registry to interact with existing editors
+        if (window.djangoAceRegistry == null ) {
+            window.djangoAceRegistry = {};
+        }
+        window.djangoAceRegistry[textarea.getAttribute('name')] = editor;
+
         // Toolbar maximize/minimize button
         var min_max = toolbar.getElementsByClassName('django-ace-max_min');
         min_max[0].onclick = function() {


### PR DESCRIPTION
Hey! I tried to find some way to get editor instance to interact with it from my code. But I didn't find it so I created a global registry object with ace editor instances of this kind:

``` javascript
window.djangoAceRegistry = {formFieldName: aceEditorInstance, ...}
```

So maybe you want to merge it to upstream.

Thank you!
