### PR TITLE
Add readonly to available options

### DIFF
--- a/django_ace/static/django_ace/widget.js
+++ b/django_ace/static/django_ace/widget.js
@@ -83,6 +83,7 @@
             tabsize = widget.getAttribute('data-tabsize'),
             fontsize = widget.getAttribute('data-fontsize'),
             usesofttabs = widget.getAttribute('data-usesofttabs'),
+            readonly = widget.getAttribute('data-readonly'),
             toolbar = prev(widget);
 
         // initialize editor and attach to widget element (for use in formset:removed)
@@ -132,6 +133,9 @@
         }
         if (!!fontsize) {
             editor.setOption("fontSize", fontsize);
+        }
+        if (readonly == "true") {
+            editor.setOption("readOnly", readonly);
         }
         if (usesofttabs == "false") {
             editor.getSession().setUseSoftTabs(false);

--- a/django_ace/widgets.py
+++ b/django_ace/widgets.py
@@ -24,6 +24,7 @@ class AceWidget(forms.Textarea):
         tabsize=None,
         fontsize=None,
         toolbar=True,
+        readonly=False,
         *args,
         **kwargs
     ):
@@ -39,6 +40,7 @@ class AceWidget(forms.Textarea):
         self.tabsize = tabsize
         self.fontsize = fontsize
         self.toolbar = toolbar
+        self.readonly = readonly
         self.usesofttabs = usesofttabs
         super(AceWidget, self).__init__(*args, **kwargs)
 
@@ -78,6 +80,7 @@ class AceWidget(forms.Textarea):
         if self.fontsize:
             ace_attrs["data-fontsize"] = str(self.fontsize)
 
+        ace_attrs["data-readonly"] = "true" if self.readonly else "false"
         ace_attrs["data-showprintmargin"] = "true" if self.showprintmargin else "false"
         ace_attrs["data-showinvisibles"] = "true" if self.showinvisibles else "false"
         ace_attrs["data-usesofttabs"] = "true" if self.usesofttabs else "false"


### PR DESCRIPTION
in case the widget should be read only, this can be done by setting it
to readonly on creation or even afterwards before rendering

on creation:

```python
class SnippetForm(forms.ModelForm):
    class Meta:
        model = Snippet
        widgets = {
            'text': AceWidget(mode='html', readonly=True)
        }
        exclude = ()
```

only on "editing":

```python
class SnippetForm(forms.ModelForm):
    class Meta:
        model = Snippet
        widgets = {
            'text': AceWidget(mode='html', readonly=True)
        }
        exclude = ()

class SnippetAdmin(admin.ModelAdmin):
  form = SnippetForm

  def get_form(self, request, obj=None, **kwargs):
    form = super().get_form(request, obj, **kwargs)

    if obj is not None:
        form.base_fields['text'].disabled = True
        form.base_fields['text'].widget.readonly = True

    return form
```