### PR TITLE
Add vim keybinding and highlight active line support to AceWidget

### DIFF
--- a/django_ace/static/django_ace/widget.js
+++ b/django_ace/static/django_ace/widget.js
@@ -89,6 +89,8 @@
             useworker = widget.getAttribute('data-useworker'),
             basicautocompletion = widget.getAttribute('data-basicautocompletion'),
             liveautocompletion = widget.getAttribute('data-liveautocompletion'),
+            vimkeybinding = widget.getAttribute('data-vimkeybinding'),
+            highlightactiveline = widget.getAttribute('data-highlightactiveline'),
             toolbar = prev(widget);
 
         // initialize editor and attach to widget element (for use in formset:removed)
@@ -166,6 +168,12 @@
             // Avoid calling setOption("enableBasicAutocompletion", true) without
             // loading ext-language_tools as it gives a warning.
             editor.setOption("enableLiveAutocompletion", true);
+        }
+        if (vimkeybinding == "true") {
+            editor.setKeyboardHandler("ace/keyboard/vim");
+        }
+        if (highlightactiveline == "false") {
+            editor.setHighlightActiveLine(false);
         }
 
         // write data back to original textarea

--- a/django_ace/widgets.py
+++ b/django_ace/widgets.py
@@ -36,6 +36,8 @@ class AceWidget(forms.Textarea):
         basicautocompletion=False,
         liveautocompletion=False,
         useStrictCSP=False,
+        vimKeyBinding=False,
+        highlightActiveLine=True,
         *args,
         **kwargs,
     ):
@@ -78,6 +80,8 @@ class AceWidget(forms.Textarea):
         self.basicautocompletion = basicautocompletion
         self.liveautocompletion = liveautocompletion
         self.useStrictCSP = useStrictCSP
+        self.vimKeyBinding = vimKeyBinding
+        self.highlightActiveLine = highlightActiveLine
 
         super(AceWidget, self).__init__(*args, **kwargs)
 
@@ -101,6 +105,8 @@ class AceWidget(forms.Textarea):
             language_tools = "django_ace/ace/ext-language_tools.js"
             if language_tools not in js:
                 js.append(language_tools)
+        if self.vimKeyBinding:
+            js.append("django_ace/ace/keybinding-vim.js")
 
         return forms.Media(js=js, css={"screen": css})
 
@@ -148,6 +154,10 @@ class AceWidget(forms.Textarea):
             "true" if self.liveautocompletion else "false"
         )
         ace_attrs["data-usestrictcsp"] = "true" if self.useStrictCSP else "false"
+        ace_attrs["data-vimkeybinding"] = "true" if self.vimKeyBinding else "false"
+        ace_attrs["data-highlightactiveline"] = (
+            "true" if self.highlightActiveLine else "false"
+        )
 
         textarea = super(AceWidget, self).render(name, value, attrs, renderer)
 


### PR DESCRIPTION
# PR: Add Vim Keybinding and Highlight Active Line Support to django-ace

## Summary
This PR adds support for Vim keybindings and control over active line highlighting in the django-ace widget, providing users with enhanced editor functionality.

## Changes

### 1. `django_ace/widgets.py`
- Added `vimKeyBinding=False` parameter to `AceWidget.__init__`
- Added `highlightActiveLine=True` parameter to `AceWidget.__init__`
- Store both parameters as instance variables
- Include vim keybinding JS file in media when enabled
- Add `data-vimkeybinding` and `data-highlightactiveline` attributes to rendered widget

### 2. `django_ace/static/django_ace/widget.js`
- Read `data-vimkeybinding` attribute from widget and apply vim keybinding when enabled using `editor.setKeyboardHandler("ace/keyboard/vim")`
- Read `data-highlightactiveline` attribute from widget and disable active line highlighting when set to false

### 3. Example Application Updates
- Added `VimSnippetForm` demonstrating both vim keybinding and highlight active line features
- Updated view and template to show both standard and enhanced editors

### 4. `pyproject.toml`
- Updated Python version requirement from `> 2` to `>=3.8` for modern Django compatibility
- Updated Django dependency from `>=2` to `>=3.2`

## Usage

```python
from django_ace import AceWidget

class MyForm(forms.Form):
    code = forms.CharField(widget=AceWidget(
        mode='python',
        theme='monokai',
        vimKeyBinding=True,        # Enable vim keybindings
        highlightActiveLine=False, # Disable active line highlighting
    ))
```

## Features

### Vim Keybindings
When enabled, users can:
- Press 'i' to enter insert mode
- Press 'Esc' to return to command mode
- Use standard vim commands like 'dd', 'yy', 'p', etc.

### Highlight Active Line Control
- By default, ACE highlights the current line (existing behavior preserved)
- Setting `highlightActiveLine=False` disables this highlighting
- Useful for cleaner appearance or when vim keybindings are used

## Testing
Both features have been tested in the example application. The vim keybinding file (`keybinding-vim.js`) is already included in the ACE distribution within django-ace.

## Backward Compatibility
This change is fully backward compatible:
- `vimKeyBinding` parameter defaults to `False`
- `highlightActiveLine` parameter defaults to `True` (preserves existing behavior)
- All existing widgets will continue to work exactly as before